### PR TITLE
Set max time on the timeline to Infinity.

### DIFF
--- a/js/animations/timeline.js
+++ b/js/animations/timeline.js
@@ -201,7 +201,7 @@ const Timeline = {
 		},
 	},
 	setTime(seconds, editing) {
-		seconds = limitNumber(seconds, 0, 1000)
+		seconds = limitNumber(seconds, 0, Infinity)
 		Timeline.vue._data.playhead = seconds
 		Timeline.time = seconds
 		if (!editing) {


### PR DESCRIPTION
Removes the previous maximum time of 1000 seconds from the timeline, which prevented making very large animations in Blockbench